### PR TITLE
Replace hardcoded credentials with config file (fixes #3)

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,6 @@
+{
+  "wifi_url": "http://192.168.1.1/login",
+  "username": "your_username",
+  "password": "your_password",
+  "product_type": "router"
+}

--- a/wifi_auto_login.py
+++ b/wifi_auto_login.py
@@ -2,8 +2,27 @@ import sqlite3
 import requests
 import datetime
 import re
+import json
+import os
 
-# Database setup
+# --- CONFIGURATION ---
+CONFIG_PATH = "config.json"
+
+# Error handling if config.json is missing
+if not os.path.exists(CONFIG_PATH):
+    raise FileNotFoundError(
+        "Missing config.json. Please copy config.example.json to config.json and fill in your details."
+    )
+
+with open(CONFIG_PATH, "r") as f:
+    config = json.load(f)
+
+URL = config["wifi_url"]
+USERNAME = config["username"]
+PASSWORD = config["password"]
+PRODUCT_TYPE = config.get("product_type", "0")  # Default to "0" if not provided
+
+# --- DATABASE SETUP ---
 DB_NAME = "wifi_log.db"
 
 def setup_database():
@@ -35,46 +54,46 @@ def log_attempt(username, password, a, response_status, response_message):
     conn.commit()
     conn.close()
 
+# --- HELPER FUNCTIONS ---
 def extract_message(response_text):
     """Extracts the meaningful message from the XML response."""
     match = re.search(r"<message><!\[CDATA\[(.*?)\]\]></message>", response_text)
     return match.group(1) if match else "Unknown response"
 
+# --- MAIN WIFI LOGIN FUNCTION ---
 def wifi_login():
     """Perform the WiFi login request and log the result."""
-    url = "POST url from the inspect element"  # Change Required
-    username = "username"
-    password = "password"
-    a_value = str(int(datetime.datetime.now().timestamp()))  # Generate dynamic 'a' value, you may refer to the screenshots in the setup.md file
+    a_value = str(int(datetime.datetime.now().timestamp()))  # Generate dynamic 'a' value
 
     payload = {
         "mode": "191",
-        "username": username,
-        "password": password,
+        "username": USERNAME,
+        "password": PASSWORD,
         "a": a_value,
-        "producttype": "0"
+        "producttype": PRODUCT_TYPE
     }
 
     try:
-        response = requests.post(url, data=payload)
+        response = requests.post(URL, data=payload)
         response_status = response.status_code
         response_message = extract_message(response.text)
 
         print(f"\n📌 Login Attempt")
         print(f"Time: {datetime.datetime.now()}")
-        print(f"Username: {username}")
+        print(f"Username: {USERNAME}")
         print(f"Session ID (a): {a_value}")
         print(f"Status: {response_status}")
         print(f"Message: {response_message}")
         print("-" * 80)
 
         # Log the attempt in SQLite
-        log_attempt(username, password, a_value, response_status, response_message)
+        log_attempt(USERNAME, PASSWORD, a_value, response_status, response_message)
 
     except requests.exceptions.RequestException as e:
         print(f"❌ Error: {e}")
-        log_attempt(username, password, a_value, "FAILED", str(e))
+        log_attempt(USERNAME, PASSWORD, a_value, "FAILED", str(e))
 
+# --- VIEW LOGIN LOGS ---
 def view_logs(limit=5):
     """Display login logs in a readable format."""
     conn = sqlite3.connect(DB_NAME)
@@ -105,7 +124,8 @@ def view_logs(limit=5):
         print(f"Message: {message}")
         print("-" * 80)
 
+# --- MAIN EXECUTION ---
 if __name__ == "__main__":
-    setup_database()  # Ensure the database is set up
-    wifi_login()  # Attempt login
-    view_logs(5)  # Show last 5 login attempts
+    setup_database()   # Ensure the database is set up
+    wifi_login()       # Attempt login
+    view_logs(5)       # Show last 5 login attempts


### PR DESCRIPTION
### What I Did
- Removed hardcoded credentials and URLs from `wifi_auto_login.py`.
- Added support for a configuration file (`config.json`) to store:
  - WiFi login URL
  - Username
  - Password
  - Product type
- Added `config.example.json` as a template for users to create their own `config.json`.
- Updated `wifi_auto_login.py` to:
  - Read credentials from `config.json`.
  - Provide a clear error message if `config.json` is missing.
- Tested locally in a virtual environment: login attempts are logged to SQLite correctly, even with dummy credentials.

### How to Use
1. Copy `config.example.json` → `config.json`.
2. Open `config.json` and fill in:
   - `wifi_url`
   - `username`
   - `password`
   - `product_type`
3. Run the script:
   ```bash
   python wifi_auto_login.py
4.Check the logs to verify login attempts.

<img width="1017" height="420" alt="hacktober fest" src="https://github.com/user-attachments/assets/0b008409-7c1b-4284-80c7-fe468604055c" />
